### PR TITLE
fsdocs-tool update to 20.0.1

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -21,7 +21,7 @@
       ]
     },
     "fsdocs-tool": {
-      "version": "16.0.1",
+      "version": "20.0.1",
       "commands": [
         "fsdocs"
       ]


### PR DESCRIPTION
Because the system uses FSharp.Compiler.Service v43.8, the fsdocs-tool has to be upgraded from 16 to 20, to make GenerateDocs task pass.